### PR TITLE
fix: Use relative paths and cross-platform methods in TCL files

### DIFF
--- a/simulation/Receiver.tcl
+++ b/simulation/Receiver.tcl
@@ -1,23 +1,27 @@
 # Create the Vivado/Journals and Vivado/Logs directories if they do not exist
-exec mkdir -p Vivado/Journals
-exec mkdir -p Vivado/Logs
+file mkdir ./Vivado/Journals
+file mkdir ./Vivado/Logs
 
 # Create a new project in the same directory as this script
 create_project -force uart_project Vivado/Sims -part xc7z020clg484-1
 
 # Add source files
-add_files /home/deck/Documents/Edge_Runner/edge_runners/definitions_pkg.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/baud_gen.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/Divisor.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/FIFO.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/Kennedy_receiver.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/Kennedy_Transmitter.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/Mensah_UART.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/Testing/Kennedy_receiver_tb.sv
+add_files ./definitions_pkg.sv
+add_files ./uart/kennedy/baud_gen.sv
+add_files ./uart/kennedy/Divisor.sv
+add_files ./uart/kennedy/FIFO.sv
+add_files ./uart/kennedy/Kennedy_receiver.sv
+add_files ./uart/kennedy/Kennedy_Transmitter.sv
+add_files ./uart/kennedy/Mensah_UART.sv
+add_files ./uart/kennedy/Testing/Kennedy_receiver_tb.sv
 
 # Create the target directory for the testImages folder
-exec mkdir -p Vivado/Sims/uart_project.sim/sim_1/behav/xsim/
-exec cp -r /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/Testing Vivado/Sims/uart_project.sim/sim_1/behav/xsim/
+file mkdir ./Vivado/Sims/uart_project.sim/sim_1/behav/xsim/
+if {[file exists ./uart/kennedy/Testing]} {
+    file copy -force ./uart/kennedy/Testing ./Vivado/Sims/nms_project.sim/sim_1/behav/xsim/
+} else {
+    puts "Warning: testImages folder does not exist."
+}
 
 # Control where the simulation files go 
 set_property directory Vivado/Sims [get_filesets sim_1]
@@ -31,14 +35,18 @@ launch_simulation
 # Run the simulation for 150000ns
 run 150000ns
 
-# Define the backup folder for logs and journal files
+# Move stray backup log and journal files to Vivado folder
+move_to_dir [glob -nocomplain *.backup.log] ./Vivado/Logs
+move_to_dir [glob -nocomplain *.backup.jou] ./Vivado/Journals
 
-# Create the backup folder if it doesn't exist
-
-# Move all backup log and journal files to the backup folder - with error handling
+proc move_to_dir {filenames dirname} {
+    foreach filename $filenames {
+        file rename $filename [file join $dirname [file tail $filename]]
+    }
+}
 
 puts "Simulation complete. Results available in Vivado/Sims"
-puts "All backup log and journal files have been moved to $backup_folder"
+puts "All backup log and journal files have been swept into Vivado/Logs and Vivado/Journals, respectively"
 
 # Prompt user about opening waveform
 puts -nonewline "Would you like to open the waveform viewer? (y/n): "

--- a/simulation/TCL
+++ b/simulation/TCL
@@ -1,1 +1,0 @@
-file:///home/deck/Desktop/edge_runners/tcl_simulation

--- a/simulation/Transmitter.tcl
+++ b/simulation/Transmitter.tcl
@@ -1,23 +1,27 @@
 # Create the Vivado/Journals and Vivado/Logs directories if they do not exist
-exec mkdir -p Vivado/Journals
-exec mkdir -p Vivado/Logs
+file mkdir ./Vivado/Journals
+file mkdir ./Vivado/Logs
 
 # Create a new project in the same directory as this script
 create_project -force uart_project Vivado/Sims -part xc7z020clg484-1
 
 # Add source files
-add_files /home/deck/Documents/Edge_Runner/edge_runners/definitions_pkg.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/baud_gen.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/Divisor.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/FIFO.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/Kennedy_receiver.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/Kennedy_Transmitter.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/Mensah_UART.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/Testing/Kennedy_transmitter_tb.sv
+add_files ./definitions_pkg.sv
+add_files ./uart/kennedy/baud_gen.sv
+add_files ./uart/kennedy/Divisor.sv
+add_files ./uart/kennedy/FIFO.sv
+add_files ./uart/kennedy/Kennedy_receiver.sv
+add_files ./uart/kennedy/Kennedy_Transmitter.sv
+add_files ./uart/kennedy/Mensah_UART.sv
+add_files ./uart/kennedy/Testing/Kennedy_transmitter_tb.sv
 
 # Create the target directory for the testImages folder
-exec mkdir -p Vivado/Sims/uart_project.sim/sim_1/behav/xsim/
-exec cp -r /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/Testing Vivado/Sims/uart_project.sim/sim_1/behav/xsim/
+file mkdir ./Vivado/Sims/uart_project.sim/sim_1/behav/xsim/
+if {[file exists ./uart/kennedy/Testing]} {
+    file copy -force ./uart/kennedy/Testing ./Vivado/Sims/nms_project.sim/sim_1/behav/xsim/
+} else {
+    puts "Warning: testImages folder does not exist."
+}
 
 # Control where the simulation files go 
 set_property directory Vivado/Sims [get_filesets sim_1]
@@ -31,14 +35,18 @@ launch_simulation
 # Run the simulation for 150000ns
 run 150000ns
 
-# Define the backup folder for logs and journal files
+# Move stray backup log and journal files to Vivado folder
+move_to_dir [glob -nocomplain *.backup.log] ./Vivado/Logs
+move_to_dir [glob -nocomplain *.backup.jou] ./Vivado/Journals
 
-# Create the backup folder if it doesn't exist
-
-# Move all backup log and journal files to the backup folder - with error handling
+proc move_to_dir {filenames dirname} {
+    foreach filename $filenames {
+        file rename $filename [file join $dirname [file tail $filename]]
+    }
+}
 
 puts "Simulation complete. Results available in Vivado/Sims"
-puts "All backup log and journal files have been moved to $backup_folder"
+puts "All backup log and journal files have been swept into Vivado/Logs and Vivado/Journals, respectively"
 
 # Prompt user about opening waveform
 puts -nonewline "Would you like to open the waveform viewer? (y/n): "

--- a/simulation/create_vivado_project.tcl
+++ b/simulation/create_vivado_project.tcl
@@ -1,26 +1,30 @@
 # Create the Vivado/Journals and Vivado/Logs directories if they do not exist
-exec mkdir -p Vivado/Journals
-exec mkdir -p Vivado/Logs
+file mkdir ./Vivado/Journals
+file mkdir ./Vivado/Logs
 
 # Create a new project in the same directory as this script
 create_project -force nms_project Vivado/Sims -part xc7z020clg484-1
 
 # Add source files
-add_files /home/deck/Documents/Edge_Runner/edge_runners/testBench/non_max_suppression_tb.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/Non_Max_Suppresion.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/pixel_loader.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/gaussian_filter.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/gradient_calculation.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/definitions_pkg.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/line_buffer.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/sqrt_22b.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/arc_tan.sv
+add_files ./testBench/non_max_suppression_tb.sv
+add_files ./Non_Max_Suppresion.sv
+add_files ./pixel_loader.sv
+add_files ./gaussian_filter.sv
+add_files ./gradient_calculation.sv
+add_files ./definitions_pkg.sv
+add_files ./line_buffer.sv
+add_files ./sqrt_22b.sv
+add_files ./arc_tan.sv
 
 # Create the target directory for the testImages folder
-exec mkdir -p Vivado/Sims/nms_project.sim/sim_1/behav/xsim/
+file mkdir ./Vivado/Sims/nms_project.sim/sim_1/behav/xsim/
 
 # Copy the entire testImages folder to the simulation directory
-exec cp -r /home/deck/Desktop/edge_runners/testImages Vivado/Sims/nms_project.sim/sim_1/behav/xsim/
+if {[file exists ./testImages]} {
+    file copy -force ./testImages ./Vivado/Sims/nms_project.sim/sim_1/behav/xsim/
+} else {
+    puts "Warning: testImages folder does not exist."
+}
 
 # Control where the simulation files go 
 set_property directory Vivado/Sims [get_filesets sim_1]
@@ -34,15 +38,15 @@ launch_simulation
 # Run the simulation
 run 2000ns
 
-# Define the backup folder for logs and journal files
-set backup_folder "/home/deck/Documents/Edge_Runner/edge_runners/Backups_logs_journals"
+# Move stray backup log and journal files to Vivado folder
+move_to_dir [glob -nocomplain *.backup.log] ./Vivado/Logs
+move_to_dir [glob -nocomplain *.backup.jou] ./Vivado/Journals
 
-# Create the backup folder if it doesn't exist
-exec mkdir -p $backup_folder
-
-# Move all backup log and journal files to the backup folder - with error handling
-exec bash -c "find . -name \"*.backup.log\" | xargs -r mv -t $backup_folder"
-exec bash -c "find . -name \"*.backup.jou\" | xargs -r mv -t $backup_folder"
+proc move_to_dir {filenames dirname} {
+    foreach filename $filenames {
+        file rename $filename [file join $dirname [file tail $filename]]
+    }
+}
 
 puts "Simulation complete. Results available in Vivado/Sims"
-puts "All backup log and journal files have been moved to $backup_folder"
+puts "All backup log and journal files have been swept into Vivado/Logs and Vivado/Journals, respectively"

--- a/simulation/simple_nms_to_test.tcl
+++ b/simulation/simple_nms_to_test.tcl
@@ -2,8 +2,8 @@
 create_project -force nms_simple_project ./nms_simple_project -part xc7z020clg484-1
 
 # Add source files
-add_files /home/deck/Desktop/edge_runners/testBench/non_max_suppresion_simp_tb.sv
-add_files /home/deck/Desktop/edge_runners/non_max_suppression.sv
+add_files ./testBench/non_max_suppresion_simp_tb.sv
+add_files ./non_max_suppression.sv
 
 # Set the top module
 set_property top non_max_suppresion_simple_tb [get_filesets sim_1]

--- a/simulation/uart_Vivado.tcl
+++ b/simulation/uart_Vivado.tcl
@@ -1,22 +1,22 @@
 # Create the Vivado/Journals and Vivado/Logs directories if they do not exist
-exec mkdir -p Vivado/Journals
-exec mkdir -p Vivado/Logs
+file mkdir ./Vivado/Journals
+file mkdir ./Vivado/Logs
 
 # Create a new project in the same directory as this script
 create_project -force uart_project Vivado/Sims -part xc7z020clg484-1
 
 # Add source files
-add_files /home/deck/Documents/Edge_Runner/edge_runners/definitions_pkg.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/baud_gen.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/Divisor.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/FIFO.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/Kennedy_receiver.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/Kennedy_Transmitter.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/Mensah_UART.sv
-add_files /home/deck/Documents/Edge_Runner/edge_runners/uart/kennedy/Testing/Test_UART_tb.sv
+add_files ./definitions_pkg.sv
+add_files ./uart/kennedy/baud_gen.sv
+add_files ./uart/kennedy/Divisor.sv
+add_files ./uart/kennedy/FIFO.sv
+add_files ./uart/kennedy/Kennedy_receiver.sv
+add_files ./uart/kennedy/Kennedy_Transmitter.sv
+add_files ./uart/kennedy/Mensah_UART.sv
+add_files ./uart/kennedy/Testing/Test_UART_tb.sv
 
 # Create the target directory for the testImages folder
-exec mkdir -p Vivado/Sims/uart_project.sim/sim_1/behav/xsim/
+file mkdir ./Vivado/Sims/uart_project.sim/sim_1/behav/xsim/
 
 # Control where the simulation files go 
 set_property directory Vivado/Sims [get_filesets sim_1]
@@ -30,15 +30,15 @@ launch_simulation
 # Run the simulation
 run 1400000ns
 
-# Define the backup folder for logs and journal files
-set backup_folder "/home/deck/Documents/Edge_Runner/edge_runners/Backups_logs_journals"
+# Move stray backup log and journal files to Vivado folder
+move_to_dir [glob -nocomplain *.backup.log] ./Vivado/Logs
+move_to_dir [glob -nocomplain *.backup.jou] ./Vivado/Journals
 
-# Create the backup folder if it doesn't exist
-exec mkdir -p $backup_folder
-
-# Move all backup log and journal files to the backup folder - with error handling
-exec bash -c "find . -name \"*.backup.log\" | xargs -r mv -t $backup_folder"
-exec bash -c "find . -name \"*.backup.jou\" | xargs -r mv -t $backup_folder"
+proc move_to_dir {filenames dirname} {
+    foreach filename $filenames {
+        file rename $filename [file join $dirname [file tail $filename]]
+    }
+}
 
 puts "Simulation complete. Results available in Vivado/Sims"
-puts "All backup log and journal files have been moved to $backup_folder"
+puts "All backup log and journal files have been swept into Vivado/Logs and Vivado/Journals, respectively"


### PR DESCRIPTION
This pull request replaces the Linux-specific `exec` statements with cross-platform versions and replaces absolute paths with relative ones so the TCL scripts can run on computers other than the ones they were originally written for. 

It also sweeps the backup files into `./Vivado/Logs` and `./Vivado/Journals` to match the paths used in the command recommend by the readme.