### PR TITLE
Automate file sending with a TCL script

### DIFF
--- a/scripts/send_files.tcl
+++ b/scripts/send_files.tcl
@@ -1,0 +1,52 @@
+#!/usr/bin/env tclsh
+
+proc send_file {source server destination} {
+  set timestamp [clock format [clock seconds] -format "%Y%m%d%H%M%S"]
+  
+  # Function to create mkdir commands for all parent directories
+  proc create_mkdir_commands {path} {
+    set parts [split $path "/"]
+    set parent_path ""
+    set cmds ""
+    foreach part $parts {
+      if {$part ne ""} {
+        append parent_path "$part"
+        if {[llength $parts] > 1} {
+          append cmds "-mkdir $parent_path\n"
+        }
+        append parent_path "/"
+        set parts [lrange $parts 1 end]
+      }
+    }
+    return $cmds
+  }
+
+  # Create mkdir commands for the destination and trash paths
+  set commands [create_mkdir_commands "$destination/$source"]
+  append commands [create_mkdir_commands ".trash/${timestamp}_$destination/$source"]
+
+  # Define the SFTP batch commands
+  append commands "-rename $destination/$source .trash/${timestamp}_$destination/$source\n"
+  append commands "put $source $destination/$source"
+
+  # Execute sftp with the script and interactive password prompt
+  if {[string equal $::tcl_platform(platform) "windows"]} {
+    exec -ignorestderr sftp -q -P 222 -oHostKeyAlgorithms=+ssh-rsa -oStrictHostKeyChecking=no $server << $commands 2>NUL
+  } else {
+    exec -ignorestderr sftp -q -P 222 -oHostKeyAlgorithms=+ssh-rsa -oStrictHostKeyChecking=no $server << $commands 2>/dev/null
+  }
+}
+
+if { $argc != 2 } {
+  puts "Usage: $argv0 <source_file> <username>@<server>:<destination>"
+  puts "Example: $argv0 simulation/create_vivado_project.tcl bob@127.2.6.6:canny_edge"
+  exit 1
+}
+
+set source_file [lindex $argv 0]
+set server_destination [lindex $argv 1]
+
+# Split the server and destination
+regexp {([^@]+@[^:]+):(.*)} $server_destination -> server destination
+
+send_file $source_file $server $destination

--- a/scripts/trash.cron
+++ b/scripts/trash.cron
@@ -1,0 +1,1 @@
+*/5 * * * * mkdir -p ~/.trash && rm -rf ~/.trash/* > /dev/null 2>&1


### PR DESCRIPTION
Since the SFTP service is very restrictive, files can't replace existing files on the server when sent by SFTP. To work around this, remote files can be renamed to release the filename so the new copy of it can be given the old file's name. The old file can later be removed by crontab or manually by the user when the login with a shell terminal. 

This pull request implements that approach with two files:

1. A TCL script that creates directories and renames the old file before attempting to send the new file.
2. A crontab that can be installed with `crontab trash.cron`, which deletes the contents of the `~/.trash` folder every five minutes.

In combination, this pull request creates a mechanism for sending files to replace existing files without cluttering up the disk with a copy of every previous version of a file.

The script works best when called from the root of the repository. It takes two arguments:

1. The local path of the file to send. This should be a relative path without a leading `./` because the script is pretty simple right now. 
2. The remote server destination in `scp` structure, like `username@server:path`. If the path does not have a leading `/`, the destination is relative to the user's home directory on the remote server.

Example:

```sh
cd root_of_repository
tclsh scripts/send_file.tcl simulation/create_vivado_project.tcl bob@127.2.6.6:canny_edge
```

The above example will result in an attempt to connect to the SFTP server on port 222 of `127.2.6.6` with username `bob` and put the file `simulation/create_vivado_project.tcl` at `canny_edge/simulation/create_vivado_project.tcl`. Since paths are relative, the destination folder's absolute path would be `/home/bob/canny_edge/simulation/create_vivado_project.tcl` (assuming the user's home directory is `/home/bob`). If there is an existing file with that name, it will be moved to `/home/bob/.trash/20250330123044_canny_edge/simulation/create_vivado_project.tcl` (assuming the command was executed at 12:30:44pm on 2025-03-30). If the user has installed the `trash.cron` file, the `.trash` folder will be automatically emptied every five minutes, eliminating any buildup of clutter.